### PR TITLE
feat: Refresh Token Rotation 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+.env
+
 ### IntelliJ IDEA ###
 .idea/modules.xml
 .idea/jarRepositories.xml

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,8 +4,10 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="false" />
+        <option name="testRunner" value="PLATFORM" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="corretto-11" />
+        <option name="gradleJvm" value="21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 test {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,12 +1,16 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    id 'org.springframework.boot' version '3.2.3' // 마이그레이션
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'org.sake'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = '11'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 
 configurations {
     compileOnly {
@@ -19,31 +23,29 @@ repositories {
 }
 
 dependencies {
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
-
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // Project Modules
     implementation project(':db')
     implementation project(':common')
 
-    //jpa
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // springdoc-openapi
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
 
-    implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
-
-    //jwt
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
-
-
-
-
-
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 test {

--- a/api/src/main/java/org/sake/api/common/api/Api.java
+++ b/api/src/main/java/org/sake/api/common/api/Api.java
@@ -1,11 +1,11 @@
 package org.sake.api.common.api;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.sake.api.common.error.ErrorCodeIfs;
 
-import javax.validation.Valid;
 
 @Data
 @NoArgsConstructor

--- a/api/src/main/java/org/sake/api/common/error/TokenErrorCode.java
+++ b/api/src/main/java/org/sake/api/common/error/TokenErrorCode.java
@@ -16,7 +16,9 @@ public enum TokenErrorCode implements ErrorCodeIfs {
 
     TOKEN_EXCEPTION(400, 2002, "토큰 알 수 없는 에러"),
 
-    AUTHORIZATION_TOKEN_NOT_FOUND(400, 2003,"인증 헤더 토큰 없음")
+    AUTHORIZATION_TOKEN_NOT_FOUND(400, 2003,"인증 헤더 토큰 없음"),
+
+    TOKEN_MISMATCH(400, 2003, "토큰 불일치")
     ;
 
     private final Integer httpStatusCode;

--- a/api/src/main/java/org/sake/api/config/redis/RedisConfig.java
+++ b/api/src/main/java/org/sake/api/config/redis/RedisConfig.java
@@ -1,0 +1,37 @@
+package org.sake.api.config.redis;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.time.Duration;
+
+@Configuration
+@Slf4j
+public class RedisConfig {
+    @Value("${REDIS_HOST}")
+    private String host;
+
+    @Value("${REDIS_PORT}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
+
+        LettuceClientConfiguration clientConfig =
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofSeconds(1)) //No longer than 1 second
+                        .shutdownTimeout(Duration.ZERO) //Immediately shutdown after application shutdown
+                        .build();
+
+        log.info("Connected to Redis at {}:{}", host, port);
+        return new LettuceConnectionFactory(redisConfig, clientConfig);
+    }
+
+}

--- a/api/src/main/java/org/sake/api/domain/store/controller/StoreOpenApiController.java
+++ b/api/src/main/java/org/sake/api/domain/store/controller/StoreOpenApiController.java
@@ -1,5 +1,6 @@
 package org.sake.api.domain.store.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sake.api.common.api.Api;
 import org.sake.api.domain.store.business.StoreBusiness;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
 
 @RequiredArgsConstructor
 @RestController

--- a/api/src/main/java/org/sake/api/domain/store/controller/model/StoreRegisterRequest.java
+++ b/api/src/main/java/org/sake/api/domain/store/controller/model/StoreRegisterRequest.java
@@ -1,12 +1,12 @@
 package org.sake.api.domain.store.controller.model;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.sake.db.store.enums.StoreCategory;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 

--- a/api/src/main/java/org/sake/api/domain/storemenu/controller/StoreMenuOpenApiController.java
+++ b/api/src/main/java/org/sake/api/domain/storemenu/controller/StoreMenuOpenApiController.java
@@ -7,7 +7,7 @@ import org.sake.api.domain.storemenu.controller.model.StoreMenuRegisterRequest;
 import org.sake.api.domain.storemenu.controller.model.StoreMenuResponse;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @RequiredArgsConstructor
 @RestController

--- a/api/src/main/java/org/sake/api/domain/storemenu/controller/model/StoreMenuRegisterRequest.java
+++ b/api/src/main/java/org/sake/api/domain/storemenu/controller/model/StoreMenuRegisterRequest.java
@@ -4,8 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 @Data

--- a/api/src/main/java/org/sake/api/domain/token/Ifs/TokenHelperIfs.java
+++ b/api/src/main/java/org/sake/api/domain/token/Ifs/TokenHelperIfs.java
@@ -1,13 +1,14 @@
 package org.sake.api.domain.token.Ifs;
 
+import org.sake.api.domain.token.entity.RefreshToken;
 import org.sake.api.domain.token.model.TokenDto;
 
 import java.util.Map;
 
 public interface TokenHelperIfs {
 
-    TokenDto issueAccessToken(Map<String, Object> data);
-    TokenDto issueRefreshToken(Map<String, Object> data);
+    TokenDto issueAccessToken(Long userId);
+    TokenDto issueRefreshToken(Long userId);
 
     Map<String, Object> validationTokenWithThrow(String token);
 

--- a/api/src/main/java/org/sake/api/domain/token/Ifs/TokenHelperIfs.java
+++ b/api/src/main/java/org/sake/api/domain/token/Ifs/TokenHelperIfs.java
@@ -9,7 +9,7 @@ public interface TokenHelperIfs {
 
     TokenDto issueAccessToken(Long userId);
     TokenDto issueRefreshToken(Long userId);
+    String validationTokenWithThrow(String token);
 
-    Map<String, Object> validationTokenWithThrow(String token);
 
 }

--- a/api/src/main/java/org/sake/api/domain/token/business/TokenBusiness.java
+++ b/api/src/main/java/org/sake/api/domain/token/business/TokenBusiness.java
@@ -6,6 +6,7 @@ import org.sake.api.common.error.ErrorCode;
 import org.sake.api.common.exception.ApiException;
 import org.sake.api.domain.token.controller.model.TokenResponse;
 import org.sake.api.domain.token.converter.TokenConverter;
+import org.sake.api.domain.token.model.TokenDto;
 import org.sake.api.domain.token.service.TokenService;
 import org.sake.db.user.UserEntity;
 
@@ -19,12 +20,7 @@ public class TokenBusiness {
 
     private final TokenConverter tokenConverter;
 
-    /**
-     * 1. user entity user Id 추출
-     * 2. access, refresh token 발행
-     * 3. converter -> token response로 변경
-     */
-
+    // userEntity에서 userId 추출 후, access token, refresh token 발행
     public TokenResponse issueToken(UserEntity userEntity){
 
         return Optional.ofNullable(userEntity)
@@ -40,11 +36,24 @@ public class TokenBusiness {
                         ()-> new ApiException(ErrorCode.NULL_POINT)
                 );
 
-
     }
 
+    // token 검증
     public Long validationAccessToken(String accessToken){
         var userId = tokenService.validationToken(accessToken);
         return userId;
     }
+
+    // Refresh Token Rotation 기법
+    public TokenResponse rotateRefreshToken(String refreshToken){
+
+        Long userId = tokenService.rotateRefreshToken(refreshToken);
+
+        // 새 token 발급
+        TokenDto accessTokenDto = tokenService.issueAccessToken(userId);
+        TokenDto refreshTokenDto = tokenService.issueRefreshToken(userId);
+
+        return tokenConverter.toResponse(accessTokenDto, refreshTokenDto);
+    }
+
 }

--- a/api/src/main/java/org/sake/api/domain/token/business/TokenBusiness.java
+++ b/api/src/main/java/org/sake/api/domain/token/business/TokenBusiness.java
@@ -28,8 +28,8 @@ public class TokenBusiness {
     public TokenResponse issueToken(UserEntity userEntity){
 
         return Optional.ofNullable(userEntity)
-                .map(ue -> {
-                    return ue.getId();
+                .map(user -> {
+                    return user.getId();
                 })
                 .map(userId -> {
                     var accessToken = tokenService.issueAccessToken(userId);

--- a/api/src/main/java/org/sake/api/domain/token/controller/TokenController.java
+++ b/api/src/main/java/org/sake/api/domain/token/controller/TokenController.java
@@ -1,0 +1,30 @@
+package org.sake.api.domain.token.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sake.api.common.api.Api;
+import org.sake.api.common.error.TokenErrorCode;
+import org.sake.api.common.exception.ApiException;
+import org.sake.api.domain.token.business.TokenBusiness;
+import org.sake.api.domain.token.controller.model.TokenResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+public class TokenController {
+
+    private final TokenBusiness tokenBusiness;
+
+    // access token 만료 시 클라이언트가 refresh token을 헤더에 넣어 서버에 요청하는 API
+    @PostMapping("refresh")
+    public Api<TokenResponse> refresh(
+            @RequestHeader("X-Refresh-Token") String refreshToken
+    ) {
+        var response = tokenBusiness.rotateRefreshToken(refreshToken);
+        return Api.OK(response);
+    }
+
+}

--- a/api/src/main/java/org/sake/api/domain/token/controller/model/TokenRequest.java
+++ b/api/src/main/java/org/sake/api/domain/token/controller/model/TokenRequest.java
@@ -8,8 +8,8 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Setter
-public class TokenResponse {
+@Getter
+public class TokenRequest {
 
     private String accessToken;
 

--- a/api/src/main/java/org/sake/api/domain/token/converter/TokenConverter.java
+++ b/api/src/main/java/org/sake/api/domain/token/converter/TokenConverter.java
@@ -21,10 +21,10 @@ public class TokenConverter {
         Objects.requireNonNull(refreshToken, ()->{throw new ApiException(ErrorCode.NULL_POINT);});
 
         return TokenResponse.builder()
-                .accessToken(accessToken.getToken())
-                .accessTokenExpiredAt(accessToken.getExpiredAt())
-                .refreshToken(refreshToken.getToken())
-                .refreshTokenExpiredAt(refreshToken.getExpiredAt())
+                .accessToken(accessToken.getAccessToken())
+                .accessTokenExpiredAt(accessToken.getAccessTokenExpiredAt())
+                .refreshToken(refreshToken.getRefreshToken())
+                .refreshTokenExpiredAt(refreshToken.getRefreshTokenExpiredAt())
                 .build();
     }
 }

--- a/api/src/main/java/org/sake/api/domain/token/entity/RefreshToken.java
+++ b/api/src/main/java/org/sake/api/domain/token/entity/RefreshToken.java
@@ -1,0 +1,24 @@
+package org.sake.api.domain.token.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 14)  // 14일
+public class RefreshToken {
+
+    @Id
+    private String refreshToken;
+
+    private Long userId;
+
+    @Builder
+    public RefreshToken(String refreshToken, Long userId) {
+        this.refreshToken = refreshToken;
+        this.userId = userId;
+    }
+}
+

--- a/api/src/main/java/org/sake/api/domain/token/entity/RefreshToken.java
+++ b/api/src/main/java/org/sake/api/domain/token/entity/RefreshToken.java
@@ -1,11 +1,11 @@
 package org.sake.api.domain.token.entity;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
-
+@NoArgsConstructor
+@Data
 @Getter
 @RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 14)  // 14일
 public class RefreshToken {

--- a/api/src/main/java/org/sake/api/domain/token/entity/RefreshTokenRepository.java
+++ b/api/src/main/java/org/sake/api/domain/token/entity/RefreshTokenRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
+
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String>{
 
+    Optional<RefreshToken> findById(String refreshToken);
+    Optional<RefreshToken> DeleteById(String refreshToken);
 }

--- a/api/src/main/java/org/sake/api/domain/token/entity/RefreshTokenRepository.java
+++ b/api/src/main/java/org/sake/api/domain/token/entity/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package org.sake.api.domain.token.entity;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String>{
+
+}

--- a/api/src/main/java/org/sake/api/domain/token/helper/JwtTokenHelper.java
+++ b/api/src/main/java/org/sake/api/domain/token/helper/JwtTokenHelper.java
@@ -12,20 +12,20 @@ import org.sake.api.domain.token.Ifs.TokenHelperIfs;
 import org.sake.api.domain.token.entity.RefreshToken;
 import org.sake.api.domain.token.entity.RefreshTokenRepository;
 import org.sake.api.domain.token.model.TokenDto;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class JwtTokenHelper implements TokenHelperIfs {
 
-    private final RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
 
     @Value("${TOKEN_SECRET_KEY}")
     private String secretKey;
@@ -100,7 +100,7 @@ public class JwtTokenHelper implements TokenHelperIfs {
 
     // token 검증
     @Override
-    public Map<String, Object> validationTokenWithThrow(String token) {
+    public String validationTokenWithThrow(String token) {
         var key = Keys.hmacShaKeyFor(secretKey.getBytes());
 
         var parser = Jwts.parserBuilder()
@@ -109,7 +109,7 @@ public class JwtTokenHelper implements TokenHelperIfs {
 
         try{
             var result = parser.parseClaimsJws(token);
-            return new HashMap<String, Object>(result.getBody());
+            return result.getBody().getSubject();
 
         }catch (Exception e){
             if(e instanceof SignatureException){
@@ -117,7 +117,7 @@ public class JwtTokenHelper implements TokenHelperIfs {
                 throw new ApiException(TokenErrorCode.INVALID_TOKEN);
             }
             else if(e instanceof ExpiredJwtException){
-                // 만료된 토큰
+                // 토큰이 만료되었을 때
                 throw new ApiException(TokenErrorCode.EXPIRED_TOKEN);
             }
             else{
@@ -126,4 +126,5 @@ public class JwtTokenHelper implements TokenHelperIfs {
             }
         }
     }
+
 }

--- a/api/src/main/java/org/sake/api/domain/token/helper/JwtTokenHelper.java
+++ b/api/src/main/java/org/sake/api/domain/token/helper/JwtTokenHelper.java
@@ -5,9 +5,12 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
 import org.sake.api.common.error.TokenErrorCode;
 import org.sake.api.common.exception.ApiException;
 import org.sake.api.domain.token.Ifs.TokenHelperIfs;
+import org.sake.api.domain.token.entity.RefreshToken;
+import org.sake.api.domain.token.entity.RefreshTokenRepository;
 import org.sake.api.domain.token.model.TokenDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,19 +22,23 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 public class JwtTokenHelper implements TokenHelperIfs {
 
-    @Value("${token.secret.key}")
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${TOKEN_SECRET_KEY}")
     private String secretKey;
 
-    @Value("${token.access-token.plus-hour}")
+    @Value("${TOKEN_ACCESS_PLUS_HOUR}")
     private Long accessTokenPlusHour;
 
-    @Value("${token.refresh-token.plus-hour}")
+    @Value("${TOKEN_REFRESH_PLUS_HOUR}")
     private Long refreshTokenPlusHour;
 
+    // access token 생성
     @Override
-    public TokenDto issueAccessToken(Map<String, Object> data) {
+    public TokenDto issueAccessToken(Long userId) {
         var expiredLocaldateTime = LocalDateTime.now().plusHours(accessTokenPlusHour);
 
         var expiredAt = Date.from(
@@ -44,19 +51,20 @@ public class JwtTokenHelper implements TokenHelperIfs {
 
         var jwtToken = Jwts.builder()
                 .signWith(key, SignatureAlgorithm.HS256)
-                .setClaims(data)
+                .setSubject(String.valueOf(userId))
                 .setExpiration(expiredAt)
                 .compact();
 
         return TokenDto.builder()
-                .token(jwtToken)
-                .expiredAt(expiredLocaldateTime)
+                .accessToken(jwtToken)
+                .accessTokenExpiredAt(expiredLocaldateTime)
                 .build();
 
     }
 
+    // refresh token 생성
     @Override
-    public TokenDto issueRefreshToken(Map<String, Object> data) {
+    public TokenDto issueRefreshToken(Long userId) {
         var expiredLocaldateTime = LocalDateTime.now().plusHours(refreshTokenPlusHour);
 
         var expiredAt = Date.from(
@@ -67,19 +75,30 @@ public class JwtTokenHelper implements TokenHelperIfs {
 
         var key = Keys.hmacShaKeyFor(secretKey.getBytes());
 
-        var jwtToken = Jwts.builder()
+        // refreshToken 생성
+        String jwtToken = Jwts.builder()
                 .signWith(key, SignatureAlgorithm.HS256)
-                .setClaims(data)
+                .setSubject(String.valueOf(userId))
                 .setExpiration(expiredAt)
                 .compact();
 
+        // Redis에 저장
+        RefreshToken token = RefreshToken.builder()
+                .refreshToken(jwtToken)
+                .userId(userId)
+                .build();
+
+        refreshTokenRepository.save(token);
+
+        // 클라이언트에게 반환 할 JWT
         return TokenDto.builder()
-                .token(jwtToken)
-                .expiredAt(expiredLocaldateTime)
+                .refreshToken(jwtToken)
+                .refreshTokenExpiredAt(LocalDateTime.now().plusHours(refreshTokenPlusHour)) // 토큰 만료 시간
                 .build();
 
     }
 
+    // token 검증
     @Override
     public Map<String, Object> validationTokenWithThrow(String token) {
         var key = Keys.hmacShaKeyFor(secretKey.getBytes());

--- a/api/src/main/java/org/sake/api/domain/token/model/TokenDto.java
+++ b/api/src/main/java/org/sake/api/domain/token/model/TokenDto.java
@@ -13,6 +13,10 @@ import java.time.LocalDateTime;
 @Builder
 
 public class TokenDto {
-    private String token;
-    private LocalDateTime expiredAt;
+
+    private String accessToken;
+    private String refreshToken;
+    private LocalDateTime accessTokenExpiredAt;
+    private LocalDateTime refreshTokenExpiredAt;
+
 }

--- a/api/src/main/java/org/sake/api/domain/token/service/TokenService.java
+++ b/api/src/main/java/org/sake/api/domain/token/service/TokenService.java
@@ -20,16 +20,15 @@ public class TokenService {
     private final TokenHelperIfs tokenHelperIfs;
 
     public TokenDto issueAccessToken(Long userId){
-        var data = new HashMap<String, Object>();
-        data.put("userId", userId);
-        return tokenHelperIfs.issueAccessToken(data);
+
+
+        return tokenHelperIfs.issueAccessToken(userId);
 
     }
 
     public TokenDto issueRefreshToken(Long userId){
-        var data = new HashMap<String, Object>();
-        data.put("userId", userId);
-        return tokenHelperIfs.issueAccessToken(data);
+
+        return tokenHelperIfs.issueRefreshToken(userId);
 
     }
 

--- a/api/src/main/java/org/sake/api/domain/token/service/TokenService.java
+++ b/api/src/main/java/org/sake/api/domain/token/service/TokenService.java
@@ -1,42 +1,78 @@
 package org.sake.api.domain.token.service;
 
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import org.sake.api.common.error.ErrorCode;
+import org.sake.api.common.error.TokenErrorCode;
 import org.sake.api.common.exception.ApiException;
 import org.sake.api.domain.token.Ifs.TokenHelperIfs;
+import org.sake.api.domain.token.controller.model.TokenResponse;
+import org.sake.api.domain.token.entity.RefreshToken;
+import org.sake.api.domain.token.entity.RefreshTokenRepository;
 import org.sake.api.domain.token.model.TokenDto;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
 import java.util.Objects;
 
-/**
- * token 에 대한 도메인로직
- */
+
 @RequiredArgsConstructor
 @Service
 public class TokenService {
 
     private final TokenHelperIfs tokenHelperIfs;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public TokenDto issueAccessToken(Long userId){
-
-
+    // access token 생성
+    public TokenDto issueAccessToken(Long userId) {
         return tokenHelperIfs.issueAccessToken(userId);
-
     }
 
-    public TokenDto issueRefreshToken(Long userId){
-
+    // refresh token 생성
+    public TokenDto issueRefreshToken(Long userId) {
         return tokenHelperIfs.issueRefreshToken(userId);
-
     }
 
-    public Long validationToken(String token){
-        var map = tokenHelperIfs.validationTokenWithThrow(token);
-        var userId = map.get("userId");
-        Objects.requireNonNull(userId, () ->{throw new ApiException(ErrorCode.NULL_POINT);});
-        return Long.parseLong(userId.toString());
+    // token 검증
+    public Long validationToken(String token) {
+        // subject == userId
+        String subject = tokenHelperIfs.validationTokenWithThrow(token);
+        Objects.requireNonNull(subject, () -> {
+            throw new ApiException(ErrorCode.NULL_POINT);
+        });
+
+        return Long.parseLong(subject);
+    }
+
+    // Refresh Token Rotation
+    public Long rotateRefreshToken(String token) {
+
+        // 토큰 유효성 검증(서명, 만료)
+        try {
+            tokenHelperIfs.validationTokenWithThrow(token);
+
+        } catch (Exception e) {
+            if (e instanceof SignatureException) {
+                throw new ApiException(TokenErrorCode.INVALID_TOKEN);
+            }
+        }
+
+        // Redis에 저장된 refresh token
+        RefreshToken oldRt = refreshTokenRepository.findById(token)
+                .orElseThrow(() -> new ApiException(TokenErrorCode.TOKEN_MISMATCH));
+
+        // Redis에 저장된 토큰과 일치하지 않는 경우 제외
+        if(!oldRt.getRefreshToken().equals(token)) {
+            throw new ApiException(TokenErrorCode.TOKEN_MISMATCH);
+        }
+
+        // userId 추출
+        Long userId = oldRt.getUserId();
+
+        // 기존 refresh token은 Redis에서 삭제
+        refreshTokenRepository.deleteById(token);
+
+        return userId;
 
 
     }

--- a/api/src/main/java/org/sake/api/domain/user/controller/UserOpenApiController.java
+++ b/api/src/main/java/org/sake/api/domain/user/controller/UserOpenApiController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @RequiredArgsConstructor
 @RestController

--- a/api/src/main/java/org/sake/api/domain/user/controller/model/UserLoginRequest.java
+++ b/api/src/main/java/org/sake/api/domain/user/controller/model/UserLoginRequest.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 @NoArgsConstructor

--- a/api/src/main/java/org/sake/api/domain/user/controller/model/UserRegisterRequest.java
+++ b/api/src/main/java/org/sake/api/domain/user/controller/model/UserRegisterRequest.java
@@ -4,8 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 @NoArgsConstructor

--- a/api/src/main/java/org/sake/api/domain/user/controller/model/UserResponse.java
+++ b/api/src/main/java/org/sake/api/domain/user/controller/model/UserResponse.java
@@ -7,9 +7,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.sake.db.user.enums.UserStatus;
 
-import javax.persistence.Column;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import java.time.LocalDateTime;
 
 @Data

--- a/api/src/main/java/org/sake/api/domain/userorder/controller/UserOrderApiController.java
+++ b/api/src/main/java/org/sake/api/domain/userorder/controller/UserOrderApiController.java
@@ -11,7 +11,7 @@ import org.sake.api.domain.userorder.controller.model.UserOrderRequest;
 import org.sake.api.domain.userorder.controller.model.UserOrderResponse;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.List;
 
 @RequiredArgsConstructor

--- a/api/src/main/java/org/sake/api/domain/userorder/controller/model/UserOrderRequest.java
+++ b/api/src/main/java/org/sake/api/domain/userorder/controller/model/UserOrderRequest.java
@@ -4,8 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-import java.util.Collection;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @Data

--- a/api/src/main/java/org/sake/api/domain/userorder/converter/UserOrderConverter.java
+++ b/api/src/main/java/org/sake/api/domain/userorder/converter/UserOrderConverter.java
@@ -6,7 +6,7 @@ import org.sake.api.domain.userorder.controller.model.UserOrderResponse;
 import org.sake.db.storemenu.StoreMenuEntity;
 import org.sake.db.userorder.UserOrderEntity;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 

--- a/api/src/main/java/org/sake/api/filter/LoggerFilter.java
+++ b/api/src/main/java/org/sake/api/filter/LoggerFilter.java
@@ -5,9 +5,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Slf4j

--- a/api/src/main/java/org/sake/api/interceptor/AuthorizationInterceptor.java
+++ b/api/src/main/java/org/sake/api/interceptor/AuthorizationInterceptor.java
@@ -13,8 +13,8 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Objects;
 
 @Slf4j

--- a/api/src/main/java/org/sake/api/interceptor/AuthorizationInterceptor.java
+++ b/api/src/main/java/org/sake/api/interceptor/AuthorizationInterceptor.java
@@ -38,7 +38,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         }
 
 
-        var accessToken = request.getHeader("authorization-token");
+        var accessToken = request.getHeader("Authorization");
         if(accessToken == null){
             throw new ApiException(TokenErrorCode.AUTHORIZATION_TOKEN_NOT_FOUND);
         }

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 spring:
   rabbitmq:
-    host: localhost
-    port: 5672
+    host: ${RABBITMQ_HOST}
+    port: ${RABBITMQ_PORT}
     username: ${RABBITMQ_USERNAME}
     password: ${RABBITMQ_PASSWORD}
 
@@ -22,9 +22,12 @@ token:
     secret:
       key: ${TOKEN_SECRET_KEY}
     access-token:
-      plus-hour: 1
+      plus-hour: ${TOKEN_ACCESS_PLUS_HOUR}
     refresh-token:
-      plus-hour: 12
+      plus-hour: ${TOKEN_REFRESH_PLUS_HOUR}
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 
 

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -2,8 +2,8 @@ spring:
   rabbitmq:
     host: localhost
     port: 5672
-    username: admin
-    password: admin123!@#
+    username: ${RABBITMQ_USERNAME}
+    password: ${RABBITMQ_PASSWORD}
 
   jpa:
     database: mysql
@@ -11,19 +11,16 @@ spring:
     properties:
       format_sql: true
       dialect: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: validate
-  # 깃허브에 절대 공유 X
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://database-sakesage.c3suqkcwcjd4.ap-northeast-2.rds.amazonaws.com:3306/sakesage?serverTimezone=Asia/Seoul&characterEncoding=UTF-8 #aws
-    #jdbc:mysql://localhost:3306/sake?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true
-    username: admin
-    password: tkzptkzptkrp24 #사케사케사게24 -영어
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
 token:
     secret:
-      key: SpringBootJWTHelperTokenSecretKeyValue123!@#
+      key: ${TOKEN_SECRET_KEY}
     access-token:
       plus-hour: 1
     refresh-token:

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,12 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.9'
-    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
-
-//dependencies{
-//    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    runtimeOnly 'mysql:mysql-connector-java'
-//}
 
 allprojects {
     repositories {
         mavenCentral()
-
     }
 }
 
@@ -22,7 +16,6 @@ bootJar {
 
 jar {
     enabled = false
-
 }
 
 group = 'org.sake'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,18 +4,17 @@ plugins {
 
 group 'org.sake'
 version '1.0-SNAPSHOT'
-sourceCompatibility = '11'
 
-repositories {
-    mavenCentral()
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
-dependencies {
-    compileOnly 'org.projectlombok:lombok:1.18.26'
-    annotationProcessor 'org.projectlombok:lombok:1.18.26'
 
-    //testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    //testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+dependencies {
+    // Lombok
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 }
 
 test {

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -6,7 +6,11 @@ plugins {
 
 group = 'org.sake'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = '11'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 
 configurations {
     compileOnly {

--- a/db/src/main/java/org/sake/db/BaseEntity.java
+++ b/db/src/main/java/org/sake/db/BaseEntity.java
@@ -1,16 +1,14 @@
 package org.sake.db;
 
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import net.bytebuddy.implementation.bind.annotation.Super;
 
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
 
 @MappedSuperclass
 @Data

--- a/db/src/main/java/org/sake/db/store/StoreEntity.java
+++ b/db/src/main/java/org/sake/db/store/StoreEntity.java
@@ -9,7 +9,7 @@ import org.sake.db.BaseEntity;
 import org.sake.db.store.enums.StoreCategory;
 import org.sake.db.store.enums.StoreStatus;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.math.BigDecimal;
 
 @Data

--- a/db/src/main/java/org/sake/db/store/StoreRepository.java
+++ b/db/src/main/java/org/sake/db/store/StoreRepository.java
@@ -4,7 +4,7 @@ import org.sake.db.store.enums.StoreCategory;
 import org.sake.db.store.enums.StoreStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import javax.persistence.Entity;
+import jakarta.persistence.*;
 import java.util.List;
 import java.util.Optional;
 

--- a/db/src/main/java/org/sake/db/storemenu/StoreMenuEntity.java
+++ b/db/src/main/java/org/sake/db/storemenu/StoreMenuEntity.java
@@ -8,7 +8,7 @@ import lombok.experimental.SuperBuilder;
 import org.sake.db.BaseEntity;
 import org.sake.db.storemenu.enums.StoreMenuStatus;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.math.BigDecimal;
 
 @Data

--- a/db/src/main/java/org/sake/db/storeuser/StoreUserEntity.java
+++ b/db/src/main/java/org/sake/db/storeuser/StoreUserEntity.java
@@ -9,7 +9,7 @@ import org.sake.db.BaseEntity;
 import org.sake.db.storeuser.enums.StoreUserRole;
 import org.sake.db.storeuser.enums.StoreUserStatus;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @SuperBuilder

--- a/db/src/main/java/org/sake/db/user/UserEntity.java
+++ b/db/src/main/java/org/sake/db/user/UserEntity.java
@@ -5,7 +5,7 @@ import lombok.experimental.SuperBuilder;
 import org.sake.db.BaseEntity;
 import org.sake.db.user.enums.UserStatus;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity

--- a/db/src/main/java/org/sake/db/userorder/UserOrderEntity.java
+++ b/db/src/main/java/org/sake/db/userorder/UserOrderEntity.java
@@ -1,6 +1,8 @@
 package org.sake.db.userorder;
 
-import com.sun.istack.NotNull;
+import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -9,7 +11,6 @@ import lombok.experimental.SuperBuilder;
 import org.sake.db.BaseEntity;
 import org.sake.db.userorder.enums.UserOrderStatus;
 
-import javax.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 

--- a/db/src/main/java/org/sake/db/userordermenu/UserOrderMenuEntity.java
+++ b/db/src/main/java/org/sake/db/userordermenu/UserOrderMenuEntity.java
@@ -1,5 +1,6 @@
 package org.sake.db.userordermenu;
 
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -8,7 +9,6 @@ import lombok.experimental.SuperBuilder;
 import org.sake.db.BaseEntity;
 import org.sake.db.userordermenu.enums.UserOrderMenuStatus;
 
-import javax.persistence.*;
 
 @Data
 @NoArgsConstructor

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'SakeWebService'
 include 'api'
+include 'common'
 include 'db'
 include 'store-admin'
-include 'common'
+
 

--- a/store-admin/build.gradle
+++ b/store-admin/build.gradle
@@ -1,12 +1,16 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'org.sake'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = '11'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 
 configurations {
     compileOnly {
@@ -20,34 +24,36 @@ repositories {
 
 dependencies {
     implementation project(':api')
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Spring Security (6.x)
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    // thymeleaf
+    // Thymeleaf (with Spring Security 6.x support)
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE' // ✅ 교체
 
-    // https://mvnrepository.com/artifact/org.thymeleaf.extras/thymeleaf-extras-springsecurity5
-    implementation group: 'org.thymeleaf.extras', name: 'thymeleaf-extras-springsecurity5', version: '3.0.4.RELEASE'
-
-
+    // RabbitMQ
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Swagger (springdoc-openapi)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0' // ✅ 교체
+
+    // Module Dependencies
     implementation project(':db')
     implementation project(':common')
 
-    //jpa
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
-    // swagger
-    implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
-
-
-
-
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 test {

--- a/store-admin/src/main/resources/application.yaml
+++ b/store-admin/src/main/resources/application.yaml
@@ -1,16 +1,3 @@
-#logging:
-#  level:
-#    org:
-#      springframework:
-#        web: DEBUG
-#      hibernate: DEBUG
-
-#http:
-#  encoding:
-#    charset: UTF-8
-#    enabled: true
-#    force: true
-
 server:
   port: 8082
 
@@ -20,8 +7,8 @@ spring:
   rabbitmq:
     host: localhost
     port: 5672
-    username: admin
-    password: admin123!@#
+    username: ${RABBITMQ_USERNAME}
+    password: ${RABBITMQ_PASSWORD}
 
 
   jpa:
@@ -30,15 +17,12 @@ spring:
     properties:
       format_sql: true
       dialect: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: validate
-  # 깃허브에 절대 공유 X
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://database-sakesage.c3suqkcwcjd4.ap-northeast-2.rds.amazonaws.com:3306/sakesage?serverTimezone=Asia/Seoul&characterEncoding=UTF-8 #aws
-    #jdbc:mysql://localhost:3306/sake?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true
-    username: admin
-    password: tkzptkzptkrp24 #사케사케사게24 -영어
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
 
 

--- a/store-admin/src/main/resources/templates/main.html
+++ b/store-admin/src/main/resources/templates/main.html
@@ -58,6 +58,7 @@
             padding: 12px;
             border-bottom: 1px solid #e0e0e0;
             text-align: left;
+            vertical-align: middle; /* 수정: 수직 정렬을 중간으로 설정 */
         }
         th {
             background-color: #f5f5f5;
@@ -67,31 +68,33 @@
         tr:hover {
             background-color: #f1f1f1;
         }
-        .button-accept {
+        .button-accept, .button-deliver {
+            width: 100px; /* 버튼의 가로 길이 조정 */
             padding: 8px 12px;
-            background-color: #17a2b8;
             color: white;
             border: none;
             cursor: pointer;
             border-radius: 5px;
             font-size: 14px;
             transition: background-color 0.3s ease;
+            margin-bottom: 8px; /* 버튼과 하단 선 사이의 간격 추가 */
+        }
+        .button-accept {
+            background-color: #17a2b8;
         }
         .button-accept:hover {
             background-color: #138496;
         }
         .button-deliver {
-            padding: 8px 12px;
             background-color: #6c757d;
-            color: white;
-            border: none;
-            cursor: pointer;
-            border-radius: 5px;
-            font-size: 14px;
-            transition: background-color 0.3s ease;
         }
         .button-deliver:hover {
             background-color: #5a6268;
+        }
+        .button-container {
+            display: flex;
+            gap: 10px;
+            flex-direction: column; /* 버튼을 수직 정렬 */
         }
         /* 모달 스타일 */
         .modal {
@@ -169,19 +172,61 @@
             </tr>
             </thead>
             <tbody>
-            <tr v-for="order in orders" :key="order.user_order_response.id">
-                <td>{{ order.user_order_response.id }}</td>
+            <tr>
+                <td>68</td>
                 <td>
                     <ul>
-                        <li v-for="item in order.store_menu_response_list" :key="item.id">
-                            {{ item.name }} {{ item.amount }}
-                        </li>
+                        <li>닷사이 3000</li>
+                        <li>홋카이산 2000</li>
                     </ul>
                 </td>
-                <td>{{ order.user_order_response.status }}</td>
+                <td>ORDER</td>
                 <td class="button-container">
-                    <button class="button-accept" @click="acceptOrder(order)">주문수락</button>
-                    <button class="button-deliver" @click="startDelivery(order)">배달시작</button>
+                    <button class="button-accept">주문수락</button>
+                    <button class="button-deliver">배달시작</button>
+                </td>
+            </tr>
+            <tr>
+                <td>67</td>
+                <td>
+                    <ul>
+                        <li>히메노아 6500</li>
+                        <li>준마이다이긴조 2000</li>
+                    </ul>
+                </td>
+                <td>ORDER</td>
+                <td class="button-container">
+                    <button class="button-accept">주문수락</button>
+                    <button class="button-deliver">배달시작</button>
+                </td>
+            </tr>
+            <tr>
+                <td>65</td>
+                <td>
+                    <ul>
+                        <li>닷사이 3000</li>
+                        <li>이토엔 1000</li>
+                        <li>긴죠 4500</li>
+                    </ul>
+                </td>
+                <td>ORDER</td>
+                <td class="button-container">
+                    <button class="button-accept">주문수락</button>
+                    <button class="button-deliver">배달시작</button>
+                </td>
+            </tr>
+            <tr>
+                <td>64</td>
+                <td>
+                    <ul>
+                        <li>준마이다이긴조 2000</li>
+                        <li>간바레 오또상 1500</li>
+                    </ul>
+                </td>
+                <td>ORDER</td>
+                <td class="button-container">
+                    <button class="button-accept">주문수락</button>
+                    <button class="button-deliver">배달시작</button>
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- Spring Boot 2.7.9 -> 3.2.3 / Java 11 -> 21 마이그레이션

- JWT 기반 Refresh Token 발행과 Redis 저장
- 토큰 관리를 위한 RTR 방식 적용: Access Token이 만료되었을 경우, 클라이언트에서 유효한 Refresh Token으로 서버에 요청하면 새 Access Token과 Refresh Token이 발행

  <br/>


## 🔧 앞으로의 과제

- 키 롤링 및 블랙리스트 적용

  <br/>
